### PR TITLE
Adding PodDisruptionBudget support

### DIFF
--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -32,7 +32,7 @@ func RootCmd() *cobra.Command {
 # Interactive operation
 $ kubectl pod-lens
 # Show pod-related resources
-$ kubectl pod-lens prometheus-prometheus-operator-prometheus-0 
+$ kubectl pod-lens prometheus-prometheus-operator-prometheus-0
 `,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -115,8 +115,8 @@ func printLogo() string {
 {{| $$                                                                     }}::white
 {{|__/                                                                     }}::white
 
-Find related {{workloads}}::green|underline, {{namespace}}::green|underline, {{node}}::green|underline, {{service}}::green|underline, {{configmap}}::green|underline, {{secret}}::green|underline, 
-{{ingress}}::green|underline {{PVC}}::green|underline and {{HPA}}::green|underline by {{pod name}}::lightRed and display them in a {{tree}}::lightBlue and {{table}}::lightBlue.
+Find related {{workloads}}::green|underline, {{namespace}}::green|underline, {{node}}::green|underline, {{service}}::green|underline, {{configmap}}::green|underline, {{secret}}::green|underline,
+{{ingress}}::green|underline, {{PVC}}::green|underline, {{HPA}}::green|underline and {{PDB}}::green|underline by {{pod name}}::lightRed and display them in a {{tree}}::lightBlue and {{table}}::lightBlue.
 Find more information at: {{https://pod-lens.guoxudong.io/}}::lightMagenta|underline
 `)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -590,12 +590,12 @@ func (sf *SnifferPlugin) printResource() error {
 		table.AddRow("Kind:", cfmt.Sprintf("{{PDB}}::cyan"))
 		table.AddRow("Name:", pdb.Name)
 		if pdb.Spec.MinAvailable != nil {
-			table.AddRow("MinAvailable:", cfmt.Sprintf("{{%d}}::lightGreen",
-				pdb.Spec.MinAvailable.IntValue()))
+			table.AddRow("MinAvailable:", cfmt.Sprintf("{{%s}}::lightGreen",
+				pdb.Spec.MinAvailable))
 		}
 		if pdb.Spec.MaxUnavailable != nil {
-			table.AddRow("MaxAvailable:", cfmt.Sprintf("{{%d}}::lightGreen",
-				pdb.Spec.MaxUnavailable.IntValue()))
+			table.AddRow("MaxAvailable:", cfmt.Sprintf("{{%s}}::lightGreen",
+				pdb.Spec.MaxUnavailable))
 		}
 		table.AddRow("Disruptions:", cfmt.Sprintf("{{%d}}::lightGreen",
 			pdb.Status.PodDisruptionsAllowed))

--- a/pkg/select-pod/template.go
+++ b/pkg/select-pod/template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/manifoldco/promptui"
 )
+
 var podTemplate = &promptui.SelectTemplates{
 	Label:    "{{ . }}",
 	Active:   fmt.Sprintf("%s {{ .Name | cyan }}", promptui.IconSelect),


### PR DESCRIPTION
This resolves #4 by bringing in PodDisruptionBudget visibility into the output.

Sample Output:
```
└─┬ [Namespace]  pdb-test                                                          
  └─┬ [Deployment]  pdb-tester                   Replica: 3/3                      
    ├─┬ [Node]  kind-control-plane               [Ready] Node IP: 172.18.0.2       
    │ └─┬ [Pod]  pdb-tester-69655c77bb-s5dc8     [Running] Pod IP: 10.244.0.10     
    │   └── [Container]  pdb-tester              [Running] Restart: 0              
    └── [ConfigMap]  kube-root-ca.crt                                              

 Related Resources 
             
Kind:        	Deployment
Name:        	pdb-tester
Replicas:    	3         
---          	---       
Kind:        	PDB       
Name:        	pdb-tester
MaxAvailable:	33%         
Disruptions: 	1         
---          	---       
```

with sample Pod/Pdb:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: pdb-tester
  name: pdb-tester
  namespace: pdb-test
spec:
  replicas: 3
  selector:
    matchLabels:
      app: pdb-tester
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 40%
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: pdb-tester
    spec:
      containers:
      - env:
        - name: START_WAIT_SECS
          value: "15"
        image: trondhindenes/k8sprobetester:latest
        imagePullPolicy: Always
        livenessProbe:
          failureThreshold: 3
          httpGet:
            httpHeaders:
            - name: Host
              value: KubernetesLivenessProbe
            path: /healthz
            port: 80
            scheme: HTTP
          initialDelaySeconds: 20
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        name: pdb-tester
        readinessProbe:
          failureThreshold: 3
          httpGet:
            httpHeaders:
            - name: Host
              value: KubernetesReadinessProbe
            path: /healthz
            port: 80
            scheme: HTTP
          initialDelaySeconds: 20
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
---
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: pdb-tester
  namespace: pdb-test
spec:
  maxUnavailable: 33%
  selector:
    matchLabels:
      app: pdb-tester

```